### PR TITLE
Fixed issue where the week year was sometimes incorrect on year changeover

### DIFF
--- a/src/jsCalendar.js
+++ b/src/jsCalendar.js
@@ -65,12 +65,15 @@ function getMonthCalender(year, month, iteratorFns){
 			var isDay = dayBefore != currentDay && i > 0;
 			var _date = new Date(year, currentMonth, day);
 
+			var returnYear = currentMonth < 0 ? year - 1 : currentMonth > 11 ? year + 1 : year;
+			if ((currentMonth === 11 || currentMonth === -1) && (weekNr === 1)) returnYear++;
+
 			var dayData = {
 				desc: isDay ? day : weekNr,
 				week: weekNr,
 				type: type,
 				date: isDay ? _date : false,
-				year: currentMonth < 0 ? year - 1 : currentMonth > 11 ? year + 1 : year,
+				year: returnYear,
 				index: cells.length
 			};
 


### PR DESCRIPTION
This is my solution to #5, it still incorporates the addition that you made.

Basically, in the month of December, if the week number is 1, then it must be the week belonging to next year, so it adjust the return year accordingly.