### PR TITLE
fix wrong week nr in US format

### DIFF
--- a/src/jsCalendar.js
+++ b/src/jsCalendar.js
@@ -98,8 +98,9 @@ function getMonthCalender(year, month, iteratorFns){
 			if (onlyDays && isDay) cells.push(dayData);	// add only days
 			else if (!onlyDays) cells.push(dayData);	// add also week numbers and labels
 		}
-		if (i > 0) weekNr = getDateInfo(year, currentMonth, day + 1, iso);
 		currentYear = getYear(year, month, weekNr);
+		if (currentMonth > 11) currentMonth = 0;
+		weekNr = getDateInfo(currentYear, currentMonth, day + 1, iso);
 	}
 
 	returnObject.cells = cells;

--- a/test/test.js
+++ b/test/test.js
@@ -66,7 +66,8 @@ describe('jsCalendar', function(){
 			testYears.forEach(function(year){
 				for (var m = 0; m < 12; m++){
 					var month = jsCal_US(year, m);
-					assert.equal(month.cells[0].week, weekUS[year][m]);
+					var firstDayOfMonth = month.cells.filter(function(cell){ return cell.type == 'monthDay'; })[0];
+					assert.equal(firstDayOfMonth.week, weekUS[year][m]);
 				}
 			});
 


### PR DESCRIPTION
@iandevlin I think this fixes the problem. Nice if you can double-check.

jsFiddle: http://jsfiddle.net/La7cwne8/2/

Not sure what to do in cases when a whole week is outside the month. Maybe add a CSS class to it (maybe another `cell.type` type). This happens so calendars get more simetric in layout.